### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.7.0 - 2022-01-13
+### Added
+- `GET /sapi/v1/mining/payment/uid` to get Mining account earning
+- `GET /sapi/v1/bswap/unclaimedRewards` to get unclaimed rewards record
+- `POST /sapi/v1/bswap/claimRewards` to claim swap rewards or liquidity rewards
+- `GET /sapi/v1/bswap/claimedHistory` to get history of claimed rewards
+- `POST /sapi/v1/sub-account/universalTransfer` to transfer spot and futures asset between master account and sub accounts
+- `GET /sapi/v1/sub-account/universalTransfer` to search transfer records
+- `GET /sapi/v2/sub-account/futures/account` to get detail on sub-account's USDT margined futures account and COIN margined futures account
+- `GET /sapi/v2/sub-account/futures/accountSummary` to get summary of sub-account's USDT margined futures account and COIN margined futures account
+- `GET /sapi/v2/sub-account/futures/positionRisk` to get position risk of sub-account's USDT margined futures account and COIN margined futures account
+
 ## v1.6.0 - 2021-12-07
 ### Added
 - `GET /api/v3/rateLimit/order` to get the current order count usage for all intervals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ accurate comments, etc.) and any other requirements (such as test coverage).
 Since the `master` branch is what people actually use in production, we have
 release candidate branches, which are usually name after `rc-`, that unstable changes get merged into first. Only when we
 consider that stable we merge it into the `master` branch and release the
-changes for real.
+changes officially.
 
 Adhering to the following process is the best way to get your work
 included in the project:
@@ -115,7 +115,7 @@ included in the project:
     git pull upstream <latest_rc_branch>
     ```
 
-3.  Create a new topic branch (off the `dev` branch) to contain your feature, change, or fix:
+3.  Create a new topic branch (off the `rc-` branch) to contain your feature, change, or fix:
 
     ```bash
     git checkout -b <topic-branch-name>

--- a/__tests__/spot/bswap/bswapClaimRewards.test.js
+++ b/__tests__/spot/bswap/bswapClaimRewards.test.js
@@ -1,0 +1,16 @@
+/* global describe, it, expect */
+const { nockPostMock, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse
+} = require('../../testUtils/mockData')
+
+describe('#bswapClaimRewards', () => {
+  it('should post to claim swap rewards or liquidity rewards', () => {
+    nockPostMock('/sapi/v1/bswap/claimRewards')(mockResponse)
+    return SpotClient.bswapClaimRewards().then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/bswap/bswapClaimedHistory.test.js
+++ b/__tests__/spot/bswap/bswapClaimedHistory.test.js
@@ -1,0 +1,16 @@
+/* global describe, it, expect */
+const { nockMock, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse
+} = require('../../testUtils/mockData')
+
+describe('#bswapClaimedHistory', () => {
+  it('should get history of claimed rewards.', () => {
+    nockMock('/sapi/v1/bswap/claimedHistory')(mockResponse)
+    return SpotClient.bswapClaimedHistory().then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/bswap/bswapUnclaimedRewards.test.js
+++ b/__tests__/spot/bswap/bswapUnclaimedRewards.test.js
@@ -1,0 +1,16 @@
+/* global describe, it, expect */
+const { nockMock, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse
+} = require('../../testUtils/mockData')
+
+describe('#bswapUnclaimedRewards', () => {
+  it('should get unclaimed rewards record', () => {
+    nockMock('/sapi/v1/bswap/unclaimedRewards')(mockResponse)
+    return SpotClient.bswapUnclaimedRewards().then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/mining/miningAccountEarning.test.js
+++ b/__tests__/spot/mining/miningAccountEarning.test.js
@@ -1,0 +1,28 @@
+/* global describe, it, expect */
+const MissingParameterError = require('../../../src/error/missingParameterError')
+const { nockMock, buildQueryString, SpotClient } = require('../../testUtils/testSetup')
+const { mockResponse, recvWindow } = require('../../testUtils/mockData')
+
+const algo = 'sha256'
+
+describe('#miningAccountEarning', () => {
+  describe('throw MissingParameterError', () => {
+    it('missing algo', () => {
+      expect(() => {
+        SpotClient.miningAccountEarning('')
+      }).toThrow(MissingParameterError)
+    })
+  })
+  it('should return account earnings', () => {
+    const parameters = {
+      algo,
+      recvWindow
+    }
+    nockMock(`/sapi/v1/mining/payment/uid?${buildQueryString(parameters)}`)(mockResponse)
+
+    return SpotClient.miningAccountEarning(algo, { recvWindow }).then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/sub_account/subAccountFuturesAccountSummaryV2.test.js
+++ b/__tests__/spot/sub_account/subAccountFuturesAccountSummaryV2.test.js
@@ -4,28 +4,29 @@ const { nockMock, buildQueryString, SpotClient } = require('../../testUtils/test
 
 const {
   mockResponse,
-  recvWindow,
-  email
+  recvWindow
 } = require('../../testUtils/mockData')
 
-describe('#subAccountFuturesAccount', () => {
+const futuresType = 2
+
+describe('#subAccountFuturesAccountSummaryV2', () => {
   describe('throw MissingParameterError', () => {
-    it('missing email', () => {
+    it('missing futuresType', () => {
       expect(() => {
-        SpotClient.subAccountFuturesAccount('')
+        SpotClient.subAccountFuturesAccountSummaryV2('')
       }).toThrow(MissingParameterError)
     })
   })
 
-  it('should get sub account futures account details', () => {
+  it('should get sub account futures acount summary based on futuresType', () => {
     const parameters = {
-      email,
+      futuresType,
       recvWindow
     }
 
-    nockMock(`/sapi/v1/sub-account/futures/account?${buildQueryString({ ...parameters })}`)(mockResponse)
+    nockMock(`/sapi/v2/sub-account/futures/accountSummary?${buildQueryString({ ...parameters })}`)(mockResponse)
 
-    return SpotClient.subAccountFuturesAccount(email, { recvWindow }).then(response => {
+    return SpotClient.subAccountFuturesAccountSummaryV2(futuresType, { recvWindow }).then(response => {
       expect(response).toBeDefined()
       expect(response.data).toEqual(mockResponse)
     })

--- a/__tests__/spot/sub_account/subAccountFuturesAccountV2.test.js
+++ b/__tests__/spot/sub_account/subAccountFuturesAccountV2.test.js
@@ -1,0 +1,44 @@
+/* global describe, it, expect */
+const MissingParameterError = require('../../../src/error/missingParameterError')
+const { nockMock, buildQueryString, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse,
+  recvWindow,
+  email
+} = require('../../testUtils/mockData')
+
+const futuresType = 2
+
+describe('#subAccountFuturesAccountV2', () => {
+  describe('throw MissingParameterError', () => {
+    it('missing email', () => {
+      expect(() => {
+        SpotClient.subAccountFuturesAccountV2('', futuresType)
+      }).toThrow(MissingParameterError)
+    })
+  })
+
+  describe('throw MissingParameterError', () => {
+    it('missing futuresType', () => {
+      expect(() => {
+        SpotClient.subAccountFuturesAccountV2(email, '')
+      }).toThrow(MissingParameterError)
+    })
+  })
+
+  it('should get sub account futures acount details based on futuresType', () => {
+    const parameters = {
+      email,
+      futuresType,
+      recvWindow
+    }
+
+    nockMock(`/sapi/v2/sub-account/futures/account?${buildQueryString({ ...parameters })}`)(mockResponse)
+
+    return SpotClient.subAccountFuturesAccountV2(email, futuresType, { recvWindow }).then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/sub_account/subAccountFuturesPositionRiskV2.test.js
+++ b/__tests__/spot/sub_account/subAccountFuturesPositionRiskV2.test.js
@@ -1,0 +1,44 @@
+/* global describe, it, expect */
+const MissingParameterError = require('../../../src/error/missingParameterError')
+const { nockMock, buildQueryString, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse,
+  recvWindow,
+  email
+} = require('../../testUtils/mockData')
+
+const futuresType = 2
+
+describe('#subAccountFuturesPositionRiskV2', () => {
+  describe('throw MissingParameterError', () => {
+    it('missing email', () => {
+      expect(() => {
+        SpotClient.subAccountFuturesPositionRiskV2('', futuresType)
+      }).toThrow(MissingParameterError)
+    })
+  })
+
+  describe('throw MissingParameterError', () => {
+    it('missing futuresType', () => {
+      expect(() => {
+        SpotClient.subAccountFuturesPositionRiskV2(email, '')
+      }).toThrow(MissingParameterError)
+    })
+  })
+
+  it('should get sub account futures position risk based on futuresType', () => {
+    const parameters = {
+      email,
+      futuresType,
+      recvWindow
+    }
+
+    nockMock(`/sapi/v2/sub-account/futures/positionRisk?${buildQueryString({ ...parameters })}`)(mockResponse)
+
+    return SpotClient.subAccountFuturesPositionRiskV2(email, futuresType, { recvWindow }).then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/sub_account/subAccountUniversalTransfer.test.js
+++ b/__tests__/spot/sub_account/subAccountUniversalTransfer.test.js
@@ -1,0 +1,44 @@
+/* global describe, it, expect */
+const MissingParameterError = require('../../../src/error/missingParameterError')
+const { nockPostMock, buildQueryString, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse,
+  recvWindow,
+  asset,
+  amount
+} = require('../../testUtils/mockData')
+
+const fromAccountType = 'SPOT'
+const toAccountType = 'USDT_FUTURE'
+
+describe('#subAccountUniversalTransfer', () => {
+  it.each([
+    [undefined, undefined, undefined, undefined], ['', '', '', ''], [null, null, null, null],
+    ['', toAccountType, asset, amount],
+    [fromAccountType, '', asset, amount],
+    [fromAccountType, toAccountType, '', amount],
+    [fromAccountType, toAccountType, asset, '']
+  ])('should throw MissingParameterError', (fromAccountType, toAccountType, asset, amount) => {
+    expect(() => {
+      SpotClient.subAccountUniversalTransfer(fromAccountType, toAccountType, asset, amount)
+    }).toThrow(MissingParameterError)
+  })
+
+  it('should do universal transfer', () => {
+    const parameters = {
+      fromAccountType,
+      toAccountType,
+      asset,
+      amount,
+      recvWindow
+    }
+
+    nockPostMock(`/sapi/v1/sub-account/universalTransfer?${buildQueryString({ ...parameters })}`)(mockResponse)
+
+    return SpotClient.subAccountUniversalTransfer(fromAccountType, toAccountType, asset, amount, { recvWindow }).then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/__tests__/spot/sub_account/subAccountUniversalTransferHistory.test.js
+++ b/__tests__/spot/sub_account/subAccountUniversalTransferHistory.test.js
@@ -1,0 +1,24 @@
+/* global describe, it, expect */
+const { nockMock, buildQueryString, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse,
+  recvWindow,
+  startTime
+} = require('../../testUtils/mockData')
+
+describe('#subAccountUniversalTransferHistory', () => {
+  it('should get universal transfer history', () => {
+    const parameters = {
+      startTime,
+      recvWindow
+    }
+
+    nockMock(`/sapi/v1/sub-account/universalTransfer?${buildQueryString({ ...parameters })}`)(mockResponse)
+
+    return SpotClient.subAccountUniversalTransferHistory({ startTime, recvWindow }).then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/examples/spot/bswap/bswapClaimRewards.js
+++ b/examples/spot/bswap/bswapClaimRewards.js
@@ -1,0 +1,9 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.bswapClaimRewards({ type: 1 })
+  .then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/bswap/bswapClaimedHistory.js
+++ b/examples/spot/bswap/bswapClaimedHistory.js
@@ -1,0 +1,9 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.bswapClaimedHistory({ poolId: 52, assetRewards: 'BNB', type: 1 })
+  .then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/bswap/bswapUnclaimedRewards.js
+++ b/examples/spot/bswap/bswapUnclaimedRewards.js
@@ -1,0 +1,9 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.bswapUnclaimedRewards({ type: 1 })
+  .then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/mining/miningAccountEarning.js
+++ b/examples/spot/mining/miningAccountEarning.js
@@ -1,0 +1,8 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.miningAccountEarning('sha256').then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/sub_account/subAccountFuturesAccountSummaryV2.js
+++ b/examples/spot/sub_account/subAccountFuturesAccountSummaryV2.js
@@ -1,0 +1,8 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.subAccountFuturesAccountSummaryV2(2).then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/sub_account/subAccountFuturesAccountV2.js
+++ b/examples/spot/sub_account/subAccountFuturesAccountV2.js
@@ -1,0 +1,11 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.subAccountFuturesAccountV2(
+  'alice@test.com', // email
+  2 // futuresType
+).then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/sub_account/subAccountFuturesPositionRiskV2.js
+++ b/examples/spot/sub_account/subAccountFuturesPositionRiskV2.js
@@ -1,0 +1,11 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.subAccountFuturesPositionRiskV2(
+  'alice@test.com', // email
+  2 // futuresType
+).then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/sub_account/subAccountUniversalTransfer.js
+++ b/examples/spot/sub_account/subAccountUniversalTransfer.js
@@ -1,0 +1,13 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.subAccountUniversalTransfer(
+  'SPOT', // fromAccountType
+  'USDT_FUTURE', // toAccountType
+  'USDT', // asset
+  1 // amount
+).then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/examples/spot/sub_account/subAccountUniversalTransferHistory.js
+++ b/examples/spot/sub_account/subAccountUniversalTransferHistory.js
@@ -1,0 +1,8 @@
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.subAccountUniversalTransferHistory().then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@binance/connector",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@binance/connector",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@binance/connector",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "This is a lightweight library that works as a connector to the Binance public API.",
   "main": "src/index.js",
   "scripts": {

--- a/src/modules/bswap.js
+++ b/src/modules/bswap.js
@@ -270,6 +270,68 @@ const Bswap = superclass => class extends superclass {
       Object.assign(options, { poolId, type, quoteAsset, shareAmount })
     )
   }
+
+  /**
+   * Get Unclaimed Rewards Record (USER_DATA)
+   *
+   * GET /sapi/v1/bswap/unclaimedRewards<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#get-unclaimed-rewards-record-user_data}
+   *
+   * @param {object} [options]
+   * @param {number} [options.type] - 0: Swap rewards,1:Liquidity rewards, default to 0
+   * @param {number} [options.recvWindow] - The value cannot be greater than 60000
+   */
+  bswapUnclaimedRewards (options = {}) {
+    return this.signRequest(
+      'GET',
+      '/sapi/v1/bswap/unclaimedRewards',
+      options
+    )
+  }
+
+  /**
+   * Claim rewards (TRADE)
+   *
+   * POST /sapi/v1/bswap/claimRewards<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#claim-rewards-trade}
+   *
+   * @param {object} [options]
+   * @param {number} [options.type] - 0: Swap rewards,1:Liquidity rewards, default to 0
+   * @param {number} [options.recvWindow] - The value cannot be greater than 60000
+   */
+  bswapClaimRewards (options = {}) {
+    return this.signRequest(
+      'POST',
+      '/sapi/v1/bswap/claimRewards',
+      options
+    )
+  }
+
+  /**
+   * Get Claimed History (USER_DATA)
+   *
+   * GET /sapi/v1/bswap/claimedHistory<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#get-claimed-history-user_data}
+   *
+   * @param {object} [options]
+   * @param {number} [options.poolId]
+   * @param {string} [options.assetRewards]
+   * @param {number} [options.type] - 0: Swap rewards,1:Liquidity rewards, default to 0
+   * @param {number} [options.startTime]
+   * @param {number} [options.endTime]
+   * @param {number} [options.limit] - default 3, max 100
+   * @param {number} [options.recvWindow] - The value cannot be greater than 60000
+   */
+  bswapClaimedHistory (options = {}) {
+    return this.signRequest(
+      'GET',
+      '/sapi/v1/bswap/claimedHistory',
+      options
+    )
+  }
 }
 
 module.exports = Bswap

--- a/src/modules/margin.js
+++ b/src/modules/margin.js
@@ -731,10 +731,9 @@ const Margin = superclass => class extends superclass {
    *
    * @param {string} asset
    * @param {object} [options]
-   * @param {number} [options.vipLevel]
-   * @param {number} [options.startTime]
-   * @param {number} [options.endTime]
-   * @param {number} [options.limit]
+   * @param {number} [options.vipLevel] - Default: user's vip level
+   * @param {number} [options.startTime] - Default: 7 days ago
+   * @param {number} [options.endTime] - Default: present. Maximum range: 1 months.
    * @param {number} [options.recvWindow] - The value cannot be greater than 60000
    */
   marginInterestRateHistory (asset, options = {}) {

--- a/src/modules/mining.js
+++ b/src/modules/mining.js
@@ -316,6 +316,32 @@ const Mining = superclass => class extends superclass {
       })
     )
   }
+
+  /**
+   * Mining Account Earning (USER_DATA)<br>
+   *
+   * GET /sapi/v1/mining/payment/uid<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#mining-account-earning-user_data}
+   *
+   * @param {string} algo - Algorithm(sha256)
+   * @param {object} [options]
+   * @param {number} [options.startDate] - Millisecond timestamp
+   * @param {number} [options.endDate] - Millisecond timestamp
+   * @param {number} [options.pageIndex] - Default 1
+   * @param {number} [options.pageSize] - Min 10,Max 200
+   * @param {number} [options.recvWindow] - The value cannot be greater than 60000
+   */
+  miningAccountEarning (algo, options = {}) {
+    validateRequiredParameters({ algo })
+    return this.signRequest(
+      'GET',
+      '/sapi/v1/mining/payment/uid',
+      Object.assign(options, {
+        algo
+      })
+    )
+  }
 }
 
 module.exports = Mining

--- a/src/modules/subAccount.js
+++ b/src/modules/subAccount.js
@@ -711,6 +711,121 @@ const SubAccount = superclass => class extends superclass {
       Object.assign(options, { email, subAccountApiKey, ipAddress })
     )
   }
+
+  /**
+   * Universal Transfer (For Master Account)<br>
+   *
+   * POST /sapi/v1/sub-account/universalTransfer<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#universal-transfer-for-master-account}
+   *
+   * @param {string} fromAccountType - "SPOT","USDT_FUTURE","COIN_FUTURE"
+   * @param {string} toAccountType - "SPOT","USDT_FUTURE","COIN_FUTURE"
+   * @param {string} asset
+   * @param {number} amount
+   * @param {object} [options]
+   * @param {string} [options.fromEmail]
+   * @param {string} [options.toEmail]
+   * @param {string} [options.clientTranId] - Must be unique
+   * @param {number} [options.recvWindow]
+   */
+  subAccountUniversalTransfer (fromAccountType, toAccountType, asset, amount, options = {}) {
+    validateRequiredParameters({ fromAccountType, toAccountType, asset, amount })
+    return this.signRequest(
+      'POST',
+      '/sapi/v1/sub-account/universalTransfer',
+      Object.assign(options, { fromAccountType, toAccountType, asset, amount })
+    )
+  }
+
+  /**
+   * Query Universal Transfer History (For Master Account)<br>
+   *
+   * GET /sapi/v1/sub-account/universalTransfer<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#query-universal-transfer-history-for-master-account}
+   *
+   * @param {object} [options]
+   * @param {string} [options.fromEmail]
+   * @param {string} [options.toEmail]
+   * @param {string} [options.clientTranId]
+   * @param {string} [options.startTime]
+   * @param {string} [options.endTime]
+   * @param {string} [options.page] - Default 1
+   * @param {string} [options.limit] - Default 500, Max 500
+   * @param {number} [options.recvWindow]
+   */
+  subAccountUniversalTransferHistory (options = {}) {
+    return this.signRequest(
+      'GET',
+      '/sapi/v1/sub-account/universalTransfer',
+      options
+    )
+  }
+
+  /**
+   * Get Detail on Sub-account's Futures Account V2 (For Master Account)<br>
+   *
+   * GET /sapi/v2/sub-account/futures/account<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#get-detail-on-sub-account-39-s-futures-account-v2-for-master-account}
+   *
+   * @param {string} email - Sub-account email
+   * @param {number} futuresType - 1:USDT Margined Futures, 2:COIN Margined Futures
+   * @param {object} [options]
+   * @param {number} [options.recvWindow]
+   */
+  subAccountFuturesAccountV2 (email, futuresType, options = {}) {
+    validateRequiredParameters({ email, futuresType })
+    return this.signRequest(
+      'GET',
+      '/sapi/v2/sub-account/futures/account',
+      Object.assign(options, { email, futuresType })
+    )
+  }
+
+  /**
+   * Get Summary of Sub-account's Futures Account V2 (For Master Account)<br>
+   *
+   * GET /sapi/v2/sub-account/futures/accountSummary<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#get-summary-of-sub-account-39-s-futures-account-v2-for-master-account}
+   *
+   * @param {number} futuresType - 1:USDT Margined Futures, 2:COIN Margined Futures
+   * @param {object} [options]
+   * @param {number} [options.page] - default:1
+   * @param {number} [options.limit] - default:10, max:20
+   * @param {number} [options.recvWindow]
+   */
+  subAccountFuturesAccountSummaryV2 (futuresType, options = {}) {
+    validateRequiredParameters({ futuresType })
+    return this.signRequest(
+      'GET',
+      '/sapi/v2/sub-account/futures/accountSummary',
+      Object.assign(options, { futuresType })
+    )
+  }
+
+  /**
+   * Get Futures Position-Risk of Sub-account V2 (For Master Account)<br>
+   *
+   * GET /sapi/v2/sub-account/futures/positionRisk<br>
+   *
+   * {@link https://binance-docs.github.io/apidocs/spot/en/#get-futures-position-risk-of-sub-account-v2-for-master-account}
+   *
+   * @param {string} email - Sub-account email
+   * @param {number} futuresType - 1:USDT Margined Futures, 2:COIN Margined Futures
+   * @param {object} [options]
+   * @param {number} [options.recvWindow]
+   */
+  subAccountFuturesPositionRiskV2 (email, futuresType, options = {}) {
+    validateRequiredParameters({ email, futuresType })
+    return this.signRequest(
+      'GET',
+      '/sapi/v2/sub-account/futures/positionRisk',
+      Object.assign(options, { email, futuresType })
+    )
+  }
 }
 
 module.exports = SubAccount


### PR DESCRIPTION

### Added
- `GET /sapi/v1/mining/payment/uid` to get Mining account earning
- `GET /sapi/v1/bswap/unclaimedRewards` to get unclaimed rewards record
- `POST /sapi/v1/bswap/claimRewards` to claim swap rewards or liquidity rewards
- `GET /sapi/v1/bswap/claimedHistory` to get history of claimed rewards
- `POST /sapi/v1/sub-account/universalTransfer` to transfer spot and futures asset between master account and sub accounts
- `GET /sapi/v1/sub-account/universalTransfer` to search transfer records
- `GET /sapi/v2/sub-account/futures/account` to get detail on sub-account's USDT margined futures account and COIN margined futures account
- `GET /sapi/v2/sub-account/futures/accountSummary` to get summary of sub-account's USDT margined futures account and COIN margined futures account
- `GET /sapi/v2/sub-account/futures/positionRisk` to get position risk of sub-account's USDT margined futures account and COIN margined futures account
