### PR TITLE
fix(savings): make asset optional param

### DIFF
--- a/__tests__/spot/savings/savingsCustomizedPosition.test.js
+++ b/__tests__/spot/savings/savingsCustomizedPosition.test.js
@@ -1,5 +1,4 @@
 /* global describe, it, expect */
-const MissingParameterError = require('../../../src/error/missingParameterError')
 const {
   nockMock,
   buildQueryString,
@@ -14,13 +13,15 @@ const {
 } = require('../../testUtils/mockData')
 
 describe('#savingsCustomizedPosition', () => {
-  describe('throw MissingParameterError', () => {
-    it('missing asset', () => {
-      expect(() => {
-        SpotClient.savingsCustomizedPosition('')
-      }).toThrow(MissingParameterError)
+  it('should return all project position', () => {
+    nockMock('/sapi/v1/lending/project/position/list')(mockResponse)
+
+    return SpotClient.savingsCustomizedPosition().then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
     })
   })
+
   it('should return project position', () => {
     const parameters = {
       projectId,

--- a/__tests__/spot/savings/savingsFlexibleProductPosition.test.js
+++ b/__tests__/spot/savings/savingsFlexibleProductPosition.test.js
@@ -1,5 +1,4 @@
 /* global describe, it, expect */
-const MissingParameterError = require('../../../src/error/missingParameterError')
 const {
   nockMock,
   buildQueryString,
@@ -13,11 +12,12 @@ const {
 } = require('../../testUtils/mockData')
 
 describe('#savingsFlexibleProductPosition', () => {
-  describe('throw MissingParameterError', () => {
-    it('missing asset', () => {
-      expect(() => {
-        SpotClient.savingsFlexibleProductPosition('')
-      }).toThrow(MissingParameterError)
+  it('should get all flexible product position', () => {
+    nockMock('/sapi/v1/lending/daily/token/position')(mockResponse)
+
+    return SpotClient.savingsFlexibleProductPosition().then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
     })
   })
   it('should get flexible product position', () => {

--- a/src/modules/savings.js
+++ b/src/modules/savings.js
@@ -136,18 +136,16 @@ const Savings = superclass => class extends superclass {
    *
    * {@link https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-position-user_data}
    *
-   * @param {string} asset
+   * @param {string} [asset]
    * @param {object} [options]
    * @param {number} [options.recvWindow] - The value cannot be greater than 60000
    */
   savingsFlexibleProductPosition (asset, options = {}) {
-    validateRequiredParameters({ asset })
-
     return this.signRequest(
       'GET',
       '/sapi/v1/lending/daily/token/position',
       Object.assign(options, {
-        asset
+        ...(asset ? { asset } : {})
       })
     )
   }
@@ -213,20 +211,18 @@ const Savings = superclass => class extends superclass {
    *
    * {@link https://binance-docs.github.io/apidocs/spot/en/#get-fixed-activity-project-position-user_data}
    *
-   * @param {string} asset
+   * @param {string} [asset]
    * @param {object} [options]
    * @param {string} [options.projectId]
    * @param {string} [options.status] - "HOLDING", "REDEEMED"
    * @param {number} [options.recvWindow] - The value cannot be greater than 60000
    */
   savingsCustomizedPosition (asset, options = {}) {
-    validateRequiredParameters({ asset })
-
     return this.signRequest(
       'GET',
       '/sapi/v1/lending/project/position/list',
       Object.assign(options, {
-        asset
+        ...(asset ? { asset } : {})
       })
     )
   }


### PR DESCRIPTION
Sync `savingsCustomizedPosition` and `savingsFlexibleProductPosition` with docs definition:
- https://binance-docs.github.io/apidocs/spot/en/#get-flexible-product-position-user_data
- https://binance-docs.github.io/apidocs/spot/en/#get-fixed-activity-project-position-user_data

For both of them, `asset` is not a required parameter. Because with the current implementation, there is no way to get all positions in one query. Related issue: https://github.com/binance/binance-connector-node/issues/107