### PR TITLE
Bugfix: Prevent query string number parameters from using floating point notation, causing Binance validation 400 error

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -31,12 +31,34 @@ const buildQueryString = params => {
     .join('&')
 }
 
+const convertNumbersToDecimalString = (value) => {
+  if (typeof value !== "number") {
+    return value
+  }
+
+  // Convert the decimal value to a string with 20 decimal places
+  let str = value.toFixed(20)
+
+  // Remove trailing zeros
+  str = str.replace(/0+$/, '')
+
+  // Remove the decimal point if there are no decimal places remaining
+  if (str.charAt(str.length - 1) === '.') {
+    str = str.slice(0, -1)
+  }
+
+  return str
+}
+
 /**
  * NOTE: The array conversion logic is different from usual query string.
  * E.g. symbols=["BTCUSDT","BNBBTC"] instead of symbols[]=BTCUSDT&symbols[]=BNBBTC
  */
 const stringifyKeyValuePair = ([key, value]) => {
-  const valueString = Array.isArray(value) ? `["${value.join('","')}"]` : value
+  const valueString = Array.isArray(value)
+    ? `["${value.join('","')}"]`
+    : convertNumbersToDecimalString(value)
+
   return `${key}=${encodeURIComponent(valueString)}`
 }
 


### PR DESCRIPTION
Closes #136

This change fixes an issue with small `price` value, such as orders of price=0.0000008, e.g. for RVN/BTC
Previously this gets simplified to price=8e-7 in the query params of the url

This PR solves 400 error: 
"Illegal characters found in parameter 'price'; legal range is '^([0-9]{1,20})(\.[0-9]{1,20})?$'."

This is achieved by converting all query parameter numbers to strings with custom function that preserves decimal places and prevents floating point notation (scientific notation)
