### PR TITLE
fix: spot params example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ const privateKeyAlgo = PrivateKeyAlgo.ED25519 // for Ed25519 key
 
 const client = new Spot(apiKey, apiSecret, {
   privateKey,
-  privateKeyPassphrase // only used for encrypted key
+  privateKeyPassphrase, // only used for encrypted key
   privateKeyAlgo
 })
 


### PR DESCRIPTION
The "Key Pair Based Authentication" example contains an error in the passed parameters. The proposed correction fixes this error.