### PR TITLE
refactor: simplified if statement, removed incorrect param from JSDoc

### DIFF
--- a/src/websocketBase.js
+++ b/src/websocketBase.js
@@ -12,8 +12,7 @@ class WebsocketBase extends APIBase {
   }
 
   isConnected () {
-    if (!this.wsConnection.ws || this.wsConnection.ws.readyState !== WebSocketClient.OPEN) return false
-    return true
+    return !(!this.wsConnection.ws || this.wsConnection.ws.readyState !== WebSocketClient.OPEN);
   }
 
   initConnect (url) {
@@ -69,7 +68,6 @@ class WebsocketBase extends APIBase {
   /**
    * Unsubscribe the stream <br>
    *
-   * @param {WebSocketClient} wsConnection - websocket client instance created by ws package
    */
   disconnect () {
     if (!this.isConnected()) this.logger.warn('No connection to close.')


### PR DESCRIPTION
In my effort to maintain clean and understandable code, a few areas of improvement were identified in `src/websocketBase.js`:

1. The existing `if` statement can be made more concise without losing its intent, making it easier for contributors to grasp the logic.
  
2. A parameter documented in the JSDoc for the `disconnect` function doesn't align with its actual usage. To prevent confusion and potential mishandling in the future, it's proposed to remove this from the JSDoc.
