### PR TITLE
Add AllOrder Method to query orders

### DIFF
--- a/src/modules/restful/trade.js
+++ b/src/modules/restful/trade.js
@@ -8,6 +8,40 @@ const { validateRequiredParameters } = require('../../helpers/validation')
  * @param {*} superclass
  */
 const Trade = superclass => class extends superclass {
+
+  /**
+ * All Orders (USER_DATA)<br>
+ *
+ * GET /api/v3/allOrders<br>
+ *
+ * {@link https://binance-docs.github.io/apidocs/spot/en/#all-orders-user_data}
+ *
+ * @param {string} symbol
+ * @param {object} [options]
+ * @param {number} [options.orderId]
+ * @param {number} [options.startTime]
+ * @param {number} [options.endTime]
+ * @param {number} [options.limit]
+ * @param {number} [options.recvWindow] - The value cannot be greater than 60000
+ */
+async allOrders(symbol, options = {}) {
+  validateRequiredParameters({ symbol });
+  try {
+    const response = await this.signRequest(
+      'GET',
+      '/api/v3/allOrders',
+      Object.assign(options, {
+        symbol: symbol.toUpperCase()
+      })
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`Error getting all orders: ${error.message}`);
+    throw error;
+  }
+}
+
+  
   /**
    * Test New Order (TRADE)<br>
    *


### PR DESCRIPTION
## Pull Request Description

### Summary
This pull request adds a new method `allOrders` to the `Trade` class in order to retrieve all orders for a specific symbol using the Binance API.

### Changes
- Added a new method `allOrders` to the `Trade` class.
- The `allOrders` method makes a GET request to `/api/v3/allOrders` endpoint.
- The method takes a `symbol` parameter and optional `options` parameter to specify additional query parameters.
- The method returns the data received from the Binance API for all orders.

### Usage Example
```javascript
// Assuming you have an instance of the Trade class
const tradeInstance = new Trade();

// Specify the symbol and options (if needed)
const symbol = 'BNBUSDT';
const options = {
  // Add any additional options if required
};

// Call the allOrders method
try {
  const allOrders = await tradeInstance.allOrders(symbol, options);
  console.log('All orders:', allOrders);
} catch (error) {
  console.error('Error retrieving all orders:', error);
}