### PR TITLE
Add method giftCardBuyCode in order to create a dual-token gift card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.2 - 2024-09-24
+### Added
+- Add GiftCard endpoint:
+  - `POST /sapi/v1/giftcard/buyCode` to create a dual-token gift card
+
 ## 3.4.1 - 2024-08-19
 ### Updated
 - Updated dependencies

--- a/__tests__/spot/gift_card/giftCardBuyCode.test.js
+++ b/__tests__/spot/gift_card/giftCardBuyCode.test.js
@@ -1,0 +1,33 @@
+/* global describe, it, expect */
+const MissingParameterError = require('../../../src/error/missingParameterError')
+const { nockPostMock, buildQueryString, SpotClient } = require('../../testUtils/testSetup')
+
+const {
+  mockResponse,
+  amount
+} = require('../../testUtils/mockData')
+
+const baseToken = 'USDT'
+const faceToken = 'BNB'
+
+describe('#giftCardBuyCode', () => {
+  it.each([
+    [undefined, undefined, undefined], ['', '', ''], [null, null, null],
+    [undefined, faceToken, undefined], ['', faceToken, ''], [null, faceToken, null],
+    [baseToken, undefined, undefined], [baseToken, '', ''], [baseToken, null, null],
+    [undefined, undefined, amount], ['', '', amount], [baseToken, faceToken, null]
+  ])('should throw MissingParameterError given missing params', (baseToken, faceToken, amount) => {
+    expect(() => {
+      SpotClient.giftCardBuyCode(baseToken, faceToken, amount)
+    }).toThrow(MissingParameterError)
+  })
+
+  it('should return binance code info', () => {
+    nockPostMock(`/sapi/v1/giftcard/buyCode?${buildQueryString({ baseToken, faceToken, baseTokenAmount: amount })}`)(mockResponse)
+
+    return SpotClient.giftCardBuyCode(baseToken, faceToken, amount).then(response => {
+      expect(response).toBeDefined()
+      expect(response.data).toEqual(mockResponse)
+    })
+  })
+})

--- a/examples/spot/gift_card/giftCardBuyCode.js
+++ b/examples/spot/gift_card/giftCardBuyCode.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Spot = require('../../../src/spot')
+
+const apiKey = ''
+const apiSecret = ''
+const client = new Spot(apiKey, apiSecret)
+
+client.giftCardBuyCode('BUSD', 'BNB', 10).then(response => client.logger.log(response.data))
+  .catch(error => client.logger.error(error))

--- a/src/modules/restful/giftCard.js
+++ b/src/modules/restful/giftCard.js
@@ -31,6 +31,30 @@ const GiftCard = superclass => class extends superclass {
   }
 
   /**
+  * Create a dual-token gift card (fixed value, discount feature) (TRADE)<br>
+  *
+  * POST /sapi/v1/giftcard/buyCode<br>
+  *
+  * {@link https://binance-docs.github.io/apidocs/spot/en/#create-a-dual-token-gift-card-fixed-value-discount-feature-trade}
+  *
+  * @param {baseToken} baseToken - The token you want to pay, example: BUSD
+  * @param {faceToken} faceToken - The token you want to buy, example: BNB. If faceToken = baseToken, it's the same as createCode endpoint.
+  * @param {baseTokenAmount} amount - The base token asset quantity
+  * @param {discount} discount - Stablecoin-denominated card discount percentage
+  * @param {object} [options]
+  * @param {number} [options.recvWindow] - The value cannot be greater than 60000
+  */
+  giftCardBuyCode (baseToken, faceToken, baseTokenAmount, discount, options = {}) {
+    validateRequiredParameters({ baseToken, faceToken, baseTokenAmount })
+
+    return this.signRequest(
+      'POST',
+      '/sapi/v1/giftcard/buyCode',
+      Object.assign(options, { baseToken, faceToken, baseTokenAmount, discount })
+    )
+  }
+
+  /**
     * Redeem a Binance Code (USER_DATA)<br>
     *
     * POST /sapi/v1/giftcard/redeemCode<br>


### PR DESCRIPTION
### Summary
This pull request adds a new method `giftCardBuyCode` to the GiftCard class in order to create a dual-token gift card using the Binance API.

### Changes
Added a new method giftCardBuyCode to the GiftCard class.
The giftCardBuyCode method makes a POST request to /sapi/v1/giftcard/buyCode endpoint.
The method takes the token you want to pay, the token you want to buy, the base token asset quantity, the card discount percentage in option and optional options parameter to specify additional query parameters.
The method returns the code of the gift card.

### Usage Example
```
// Assuming you have an instance of the client
const client = new Spot(apiKey, apiSecret)

// Specify the symbol and options (if needed)
const baseToken = 'USDT';
const faceToken = 'BTC';
const options = {
  // Add any additional options if required
};

// Call the giftCardBuyCode method
try {
  const response = await client.giftCardBuyCode(baseToken, faceToken, 10)
  console.log(client.logger.log(response.data));
} catch (error) {
  console.error(client.logger.error(error));
}
```